### PR TITLE
Removed space prefix from mailto: URIs

### DIFF
--- a/_includes/cds/team-listing.html
+++ b/_includes/cds/team-listing.html
@@ -17,7 +17,7 @@
 						<div class="social-links">
 							{% if member.email != null %}
 								<span class="social-icons">
-									<a href="mailto: {{member.email}}" aria-label="Link to {{member.name}}'s Email">
+									<a href="mailto:{{member.email}}" aria-label="Link to {{member.name}}'s Email">
 										<i class="fa fa-envelope" arial-hidden="true"></i>
 									</a>
 								</span>


### PR DESCRIPTION
This was causing email addresses to get prefixed with a `%20` if the user clicked the link or copied the email address from the link.